### PR TITLE
비교현황 페이지용 기업 목록리스트 api 추가

### DIFF
--- a/controllers/companyController.js
+++ b/controllers/companyController.js
@@ -47,7 +47,8 @@ export const getCompanies = async (req, res) => {
     }),
   ]);
 
-  const bigIntToString = companies.map((company, index) => ({
+  //bigInt to string
+  const companiesWithRank = companies.map((company, index) => ({
     ...company,
     categories: company.categories.map((category) => category.name),
     actualInvestment: company.actualInvestment.toString(),
@@ -55,7 +56,7 @@ export const getCompanies = async (req, res) => {
     rank: offset + (index + 1),
   }));
 
-  res.status(200).send({ totalCount, list: bigIntToString });
+  res.status(200).send({ totalCount, list: companiesWithRank });
 };
 
 export const getCompanyById = async (req, res) => {

--- a/controllers/comparisonController.js
+++ b/controllers/comparisonController.js
@@ -197,3 +197,40 @@ export async function getSelections(req, res) {
     res.send({ message: error.message });
   }
 }
+
+//비교 현황 페이지용 기업리스트 (GET)
+export async function getComparisonStatus(req, res) {
+  const { order = "desc", sortBy = "selectedCount" } = req.query;
+  const limit = parseInt(req.query.limit) || 10;
+  //page기본값 1
+  const page = parseInt(req.query.page) || 1;
+  const offset = page ? (page - 1) * limit : 0;
+
+  const sortOptions = { [sortBy]: order };
+
+  const [totalCount, companies] = await prisma.$transaction([
+    prisma.company.count(),
+    prisma.company.findMany({
+      //데이터 동일성 위해 정렬할때 id desc순으로
+      orderBy: [sortOptions, { id: "desc" }],
+      take: limit,
+      skip: offset || 0,
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        selectedCount: true,
+        comparedCount: true,
+        categories: { select: { name: true } },
+      },
+    }),
+  ]);
+
+  const companyListWithRank = companies.map((company, index) => ({
+    ...company,
+    categories: company.categories.map((category) => category.name),
+    rank: offset + (index + 1),
+  }));
+
+  res.status(200).send({ totalCount, list: companyListWithRank });
+}

--- a/routes/comparisonRoute.js
+++ b/routes/comparisonRoute.js
@@ -6,5 +6,6 @@ const app = express.Router();
 app.get("/", comparison.getComparison);
 app.get("/rank/:id", comparison.getCompaniesRank);
 app.get("/selections", comparison.getSelections);
+app.get("/status", comparison.getComparisonStatus);
 
 export default app;


### PR DESCRIPTION
getSelections 컨트롤러가 제 비교현황 페이지용인줄 알았는데 fetch해보니 데이터가 잘못나오더라구요.
limit,page, offset 고쳐주고 rank asc 순서 바꾸면 될거 같기도 한데, (sql 건들기가 무서버서..) 
또 우현이님 다른곳에 쓰시는 api일수도 있어서
일단  그 밑에 getComparisonStatus 만들고 라우터 /comparisons/status로 추가해주었습니다!

지금 getSelections로는  아래처럼 fetch 됩니다. totalCount 14개인데 중간에 offset이 잘못되서 10개가 날아간거같아요.
![Screenshot 2024-08-20 at 9 39 40 PM](https://github.com/user-attachments/assets/c84f059e-48dd-45a3-ae2a-f3235401bcdb)

![Screenshot 2024-08-20 at 9 39 49 PM](https://github.com/user-attachments/assets/933215dc-679a-478b-aeab-f7dff711e483)

